### PR TITLE
fix: docs ordering

### DIFF
--- a/docs/Free GFG Courses/_category_.json
+++ b/docs/Free GFG Courses/_category_.json
@@ -1,8 +1,0 @@
-{
- "label": "Free GeeksForGeeks Courses",
- "position": 6,
- "link": {
-   "type": "generated-index",
-   "description": "Curation of Free GeeksForGeeks Courses"
- }
-}

--- a/docs/sd/devops.md
+++ b/docs/sd/devops.md
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 3
+sidebar_position: 4
 ---
 
 # DevOps

--- a/docs/sd/kerneldev.md
+++ b/docs/sd/kerneldev.md
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 4
+sidebar_position: 5
 ---
 
 # Kernel Development

--- a/docs/sd/webDev.md
+++ b/docs/sd/webDev.md
@@ -1,12 +1,13 @@
 ---
-sidebar_position: 1
+sidebar_position: 3
 ---
 
-# Web Development
+# Web Development (GFG)
 
 Whatever aspect of goals🥇 of web development attracts you, we have programs that can help you reach your goals.
 
 ## Frontend Development
+
 This course📚 will help geeks🧑‍💻 knowing about static web page layout using HTML elements. Also geeks will dive into the fundamentals of CSS where we will learn to customize the look of web pages.
 We understand the needs of our freshers and we believe that a student needs to get introduced to a new language💻 first in a proper manner before going on to tackle the bigger projects. For that check out:
 


### PR DESCRIPTION
gfg resources don't to be kept separately if they only have webd related links 😺 